### PR TITLE
Node filtering

### DIFF
--- a/DTOs/MutatableNode.ts
+++ b/DTOs/MutatableNode.ts
@@ -1,8 +1,9 @@
 import { IMutatableNode } from "../interfaces/IMutatableNode";
 
-export class Node implements IMutatableNode {
+export class MutatableNode implements IMutatableNode{
     constructor (
         public syntaxType: number,
         public positions: { pos: number, end: number },
-        public parentFileName: string) {}
+        public parentFileName: string
+    ) {}
 }

--- a/src/CodeInspector/CodeInspector.spec.ts
+++ b/src/CodeInspector/CodeInspector.spec.ts
@@ -1,8 +1,9 @@
-import * as ts from "typescript";
+import { SourceFile, SyntaxKind, Node } from "typescript";
 import { expect } from "chai";
+
 import { CodeInspector } from "./CodeInspector";
-import { SourceFile, SyntaxKind } from "typescript";
 import { SpecificNodeFinder } from "../../testUtilities/SpecificNodeFinder";
+import { SourceObjCreator } from "../../testUtilities/SourceObjCreator";
 
 describe("Testing CodeInspector", () => {
     let code;
@@ -16,45 +17,45 @@ describe("Testing CodeInspector", () => {
             const y: number = 11;
             const z = x+y;
         `;
-        sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
+        sourceObj = new SourceObjCreator(code).sourceObj;
         ci = new CodeInspector(sourceObj);
         nodeFinder = new SpecificNodeFinder();
     });
 
     it("All plus signs are detected", () => {
-        const actual = ci.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken);
+        const actual = ci.findObjectsOfSyntaxKind(SyntaxKind.PlusToken);
         expect(actual.length).to.equal(2);
     });
 
     it("All binary expressions are detected", () => {
-        const actual = ci.findObjectsOfSyntaxKind(ts.SyntaxKind.BinaryExpression);
+        const actual = ci.findObjectsOfSyntaxKind(SyntaxKind.BinaryExpression);
         expect(actual.length).to.equal(3);
     });
 
     it("should return false when + token is between two strings", () => {
         code = "'hello' + 'world';";
-        sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
+        sourceObj = new SourceObjCreator(code).sourceObj;
         ci = new CodeInspector(sourceObj);
 
-        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
-        const plusNode: ts.Node = allPlusNodes[0];
+        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+        const plusNode: Node = allPlusNodes[0];
         const actual = CodeInspector.checkNodeIsMutatable(plusNode);
         expect(actual).to.equal(false);
     });
 
     it("should return true when + token is between two numbers", () => {
         code = "2 + 2;";
-        sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
+        sourceObj = new SourceObjCreator(code).sourceObj;
         ci = new CodeInspector(sourceObj);
 
-        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
-        const plusNode: ts.Node = allPlusNodes[0];
+        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+        const plusNode: Node = allPlusNodes[0];
         const actual = CodeInspector.checkNodeIsMutatable(plusNode);
         expect(actual).to.equal(true);
     });
 
     it("2 plus signs are detected for mutation when 2 valid ones are placed", () => {
-        const actual = ci.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken);
+        const actual = ci.findObjectsOfSyntaxKind(SyntaxKind.PlusToken);
         expect(actual.length).to.equal(2);
     });
 });

--- a/src/CodeInspector/CodeInspector.spec.ts
+++ b/src/CodeInspector/CodeInspector.spec.ts
@@ -32,28 +32,6 @@ describe("Testing CodeInspector", () => {
         expect(actual.length).to.equal(3);
     });
 
-    it("should return false when + token is between two strings", () => {
-        code = "'hello' + 'world';";
-        sourceObj = new SourceObjCreator(code).sourceObj;
-        ci = new CodeInspector(sourceObj);
-
-        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-        const plusNode: Node = allPlusNodes[0];
-        const actual = CodeInspector.checkNodeIsMutatable(plusNode);
-        expect(actual).to.equal(false);
-    });
-
-    it("should return true when + token is between two numbers", () => {
-        code = "2 + 2;";
-        sourceObj = new SourceObjCreator(code).sourceObj;
-        ci = new CodeInspector(sourceObj);
-
-        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-        const plusNode: Node = allPlusNodes[0];
-        const actual = CodeInspector.checkNodeIsMutatable(plusNode);
-        expect(actual).to.equal(true);
-    });
-
     it("2 plus signs are detected for mutation when 2 valid ones are placed", () => {
         const actual = ci.findObjectsOfSyntaxKind(SyntaxKind.PlusToken);
         expect(actual.length).to.equal(2);

--- a/src/CodeInspector/CodeInspector.spec.ts
+++ b/src/CodeInspector/CodeInspector.spec.ts
@@ -1,4 +1,4 @@
-import { SourceFile, SyntaxKind, Node } from "typescript";
+import { SourceFile, SyntaxKind } from "typescript";
 import { expect } from "chai";
 
 import { CodeInspector } from "./CodeInspector";

--- a/src/CodeInspector/CodeInspector.spec.ts
+++ b/src/CodeInspector/CodeInspector.spec.ts
@@ -2,11 +2,13 @@ import * as ts from "typescript";
 import { expect } from "chai";
 import { CodeInspector } from "./CodeInspector";
 import { SourceFile, SyntaxKind } from "typescript";
+import { SpecificNodeFinder } from "../../testUtilities/SpecificNodeFinder";
 
 describe("Testing CodeInspector", () => {
     let code;
     let sourceObj: SourceFile;
     let ci: CodeInspector;
+    let nodeFinder: SpecificNodeFinder;
     beforeEach(() => {
         code = `
             let x: number = 3 + 9;
@@ -16,6 +18,7 @@ describe("Testing CodeInspector", () => {
         `;
         sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
         ci = new CodeInspector(sourceObj);
+        nodeFinder = new SpecificNodeFinder();
     });
 
     it("All plus signs are detected", () => {
@@ -33,8 +36,8 @@ describe("Testing CodeInspector", () => {
         sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
         ci = new CodeInspector(sourceObj);
 
-        const x = findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
-        const plusNode: ts.Node = x[0];
+        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
+        const plusNode: ts.Node = allPlusNodes[0];
         const actual = CodeInspector.checkNodeIsMutatable(plusNode);
         expect(actual).to.equal(false);
     });
@@ -44,8 +47,8 @@ describe("Testing CodeInspector", () => {
         sourceObj = ts.createSourceFile("", code, ts.ScriptTarget.ES5, true);
         ci = new CodeInspector(sourceObj);
 
-        const x = findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
-        const plusNode: ts.Node = x[0];
+        const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(ts.SyntaxKind.PlusToken, sourceObj);
+        const plusNode: ts.Node = allPlusNodes[0];
         const actual = CodeInspector.checkNodeIsMutatable(plusNode);
         expect(actual).to.equal(true);
     });
@@ -55,20 +58,3 @@ describe("Testing CodeInspector", () => {
         expect(actual.length).to.equal(2);
     });
 });
-
-let retrievedObjects;
-function findObjectsOfSyntaxKind (kind: SyntaxKind, sourceObject) {
-    retrievedObjects = [];
-    return findTokenObjectsOfKind(sourceObject, kind);
-}
-
-function findTokenObjectsOfKind (object: ts.Node, kind: SyntaxKind) {
-    if (object.kind === kind) {
-        retrievedObjects.push(object);
-    }
-    object.forEachChild((element) => {
-        findTokenObjectsOfKind(element, kind);
-    });
-    return retrievedObjects;
-}
-

--- a/src/CodeInspector/CodeInspector.ts
+++ b/src/CodeInspector/CodeInspector.ts
@@ -5,7 +5,7 @@ export class CodeInspector {
     private static retrievedObjects: Array<{pos: number, end: number}> = [];
     constructor (private sourceObject: SourceFile) {}
 
-    public static checkNodeIsMutatable (node: Node): boolean {
+    public static isNodeMutatable (node: Node): boolean {
         return !ValidMutationRules.hasStringLiteralChild(node);
     }
 
@@ -18,7 +18,7 @@ export class CodeInspector {
 
     private static findTokenObjectsOfKind (object: Node, kind: SyntaxKind)
     : Array<{pos: number, end: number}> {
-        if (object.kind === kind && CodeInspector.checkNodeIsMutatable(object)) {
+        if (object.kind === kind && CodeInspector.isNodeMutatable(object)) {
             CodeInspector.retrievedObjects.push({pos: object.pos, end: object.end});
         }
         object.forEachChild((element) => {

--- a/src/CodeInspector/CodeInspector.ts
+++ b/src/CodeInspector/CodeInspector.ts
@@ -1,4 +1,4 @@
-import { Node, SourceFile, SyntaxKind } from "typescript";
+import { Node, SourceFile, SyntaxKind, isTypeNode } from "typescript";
 import { ValidMutationRules } from "./ValidMutationRules";
 
 export class CodeInspector {
@@ -6,7 +6,9 @@ export class CodeInspector {
     constructor (private sourceObject: SourceFile) {}
 
     public static isNodeMutatable (node: Node): boolean {
-        return !ValidMutationRules.hasStringLiteralChild(node);
+        const mutationRules = new ValidMutationRules();
+        mutationRules.setNodeFamily(node);
+        return mutationRules.traverseRuleTree(ValidMutationRules.RULE_TREE, 0);
     }
 
     public findObjectsOfSyntaxKind (kind: SyntaxKind) {

--- a/src/CodeInspector/CodeInspector.ts
+++ b/src/CodeInspector/CodeInspector.ts
@@ -1,4 +1,4 @@
-import { Node, SourceFile, SyntaxKind, isTypeNode } from "typescript";
+import { Node, SourceFile, SyntaxKind } from "typescript";
 import { ValidMutationRules } from "./ValidMutationRules";
 
 export class CodeInspector {

--- a/src/CodeInspector/CodeInspector.ts
+++ b/src/CodeInspector/CodeInspector.ts
@@ -1,17 +1,12 @@
 import { Node, SourceFile, SyntaxKind } from "typescript";
+import { ValidMutationRules } from "./ValidMutationRules";
 
 export class CodeInspector {
     private static retrievedObjects: Array<{pos: number, end: number}> = [];
     constructor (private sourceObject: SourceFile) {}
 
     public static checkNodeIsMutatable (node: Node): boolean {
-        let nodeMutatable = true;
-        node.parent.forEachChild((child) => {
-            if (child.kind === SyntaxKind.StringLiteral) {
-                nodeMutatable = false;
-            }
-        });
-        return nodeMutatable;
+        return !ValidMutationRules.hasStringLiteralChild(node);
     }
 
     public findObjectsOfSyntaxKind (kind: SyntaxKind) {

--- a/src/CodeInspector/ValidMutationRules.spec.ts
+++ b/src/CodeInspector/ValidMutationRules.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from "chai";
+import { ValidMutationRules } from "./ValidMutationRules";
+import { SpecificNodeFinder } from "../../testUtilities/SpecificNodeFinder";
+import { SourceObjCreator } from "../../testUtilities/SourceObjCreator";
+import { SyntaxKind, Node } from "typescript";
+
+describe("Testing ValidMutationRules", () => {
+      let validMutationRules: ValidMutationRules;
+      let nodeFinder: SpecificNodeFinder;
+      beforeEach(() => {
+            validMutationRules = new ValidMutationRules();
+            nodeFinder = new SpecificNodeFinder();
+      });
+
+      it("should return true if node is part of binary expression", () => {
+            const code = "const x = a + b";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const plusTokens = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const tokenOfInterest = plusTokens[0];
+            expect(ValidMutationRules.isInBinaryExpression(tokenOfInterest)).to.equal(true);
+      });
+
+      it("should return false if node is NOT part of binary expression", () => {
+            const code = "return true;";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const tokens = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.TrueKeyword, sourceObj);
+            const tokenOfInterest = tokens[0];
+            expect(ValidMutationRules.isInBinaryExpression(tokenOfInterest)).to.equal(false);
+      });
+
+      it("should return true when + token is between two strings", () => {
+            const code = "'hello' + 'world';";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+
+            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const plusNode: Node = allPlusNodes[0];
+            const actual = ValidMutationRules.hasStringLiteralChild(plusNode);
+            expect(actual).to.equal(true);
+      });
+
+      it("should return false when + token is between two numbers", () => {
+            const code = "2 + 2;";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+
+            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const plusNode: Node = allPlusNodes[0];
+            const actual = ValidMutationRules.hasStringLiteralChild(plusNode);
+            expect(actual).to.equal(false);
+      });
+
+      it("should set the nodes kind to 37, parent to 194, neighbour to 8 with 3+2", () => {
+            const code = "3 + 2;";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const plusNode: Node = allPlusNodes[0];
+            ValidMutationRules.setNodeFamily(plusNode, plusNode.parent, plusNode.parent.getChildAt(0));
+            expect(ValidMutationRules.ruleDepth)
+            .to.eql([SyntaxKind.PlusToken, SyntaxKind.BinaryExpression, SyntaxKind.NumericLiteral]);
+      });
+
+      it("should get the nodes parent's children (node's neighbours) kinds ", () => {
+            const code = "3 + 2;";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const plusNode: Node = allPlusNodes[0];
+            const actual = ValidMutationRules.getNeighbourKinds(plusNode);
+            expect(actual).to.eql([8, 8]);
+      });
+
+      it("should get two neighbours when in a larger expression", () => {
+            const code = "3 + 2 + 4 + 6;";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const plusNode: Node = allPlusNodes[1];
+            const actual = ValidMutationRules.getNeighbourKinds(plusNode);
+            expect(actual.length).to.equal(2);
+      });
+
+      xit("should return false when given a string addition expression", () => {
+            const code = "'hello' + 'hey';";
+            const sourceObj = new SourceObjCreator(code).sourceObj;
+            const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
+            const node: Node = nodes[0];
+            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
+            console.log(ValidMutationRules.ruleDepth);
+            const actual = ValidMutationRules.traverseRuleTree(ValidMutationRules.RULETREE, 0);
+            expect(actual).to.equal(false);
+      });
+});

--- a/src/CodeInspector/ValidMutationRules.spec.ts
+++ b/src/CodeInspector/ValidMutationRules.spec.ts
@@ -5,7 +5,7 @@ import { SourceObjCreator } from "../../testUtilities/SourceObjCreator";
 import { SyntaxKind, Node } from "typescript";
 
 describe("Testing ValidMutationRules", () => {
-      let validMutationRules: ValidMutationRules;
+      let mutationRules: ValidMutationRules;
       let nodeFinder: SpecificNodeFinder;
       const TEST_RULE_TREE = {
             [SyntaxKind.PlusToken]: {
@@ -20,44 +20,8 @@ describe("Testing ValidMutationRules", () => {
             }
       };
       beforeEach(() => {
-            validMutationRules = new ValidMutationRules();
+            mutationRules = new ValidMutationRules();
             nodeFinder = new SpecificNodeFinder();
-      });
-
-      it("should return true if node is part of binary expression", () => {
-            const code = "const x = a + b";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-            const plusTokens = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-            const tokenOfInterest = plusTokens[0];
-            expect(ValidMutationRules.isInBinaryExpression(tokenOfInterest)).to.equal(true);
-      });
-
-      it("should return false if node is NOT part of binary expression", () => {
-            const code = "return true;";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-            const tokens = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.TrueKeyword, sourceObj);
-            const tokenOfInterest = tokens[0];
-            expect(ValidMutationRules.isInBinaryExpression(tokenOfInterest)).to.equal(false);
-      });
-
-      it("should return true when + token is between two strings", () => {
-            const code = "'hello' + 'world';";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-
-            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-            const plusNode: Node = allPlusNodes[0];
-            const actual = ValidMutationRules.hasStringLiteralChild(plusNode);
-            expect(actual).to.equal(true);
-      });
-
-      it("should return false when + token is between two numbers", () => {
-            const code = "2 + 2;";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-
-            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-            const plusNode: Node = allPlusNodes[0];
-            const actual = ValidMutationRules.hasStringLiteralChild(plusNode);
-            expect(actual).to.equal(false);
       });
 
       it("should set the nodes kind to 37, parent to 194, neighbour to 8 with 3+2", () => {
@@ -65,27 +29,9 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
             const plusNode: Node = allPlusNodes[0];
-            ValidMutationRules.setNodeFamily(plusNode, plusNode.parent, plusNode.parent.getChildAt(0));
-            expect(ValidMutationRules.nodeFamily)
+            mutationRules.setNodeFamily(plusNode);
+            expect(mutationRules.nodeFamily)
             .to.eql([SyntaxKind.PlusToken, SyntaxKind.BinaryExpression, SyntaxKind.NumericLiteral]);
-      });
-
-      it("should get the nodes parent's children (node's neighbours) kinds ", () => {
-            const code = "3 + 2;";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-            const plusNode: Node = allPlusNodes[0];
-            const actual = ValidMutationRules.getNeighbourKinds(plusNode);
-            expect(actual).to.eql([8, 8]);
-      });
-
-      it("should get two neighbours when in a larger expression", () => {
-            const code = "3 + 2 + 4 + 6;";
-            const sourceObj = new SourceObjCreator(code).sourceObj;
-            const allPlusNodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
-            const plusNode: Node = allPlusNodes[1];
-            const actual = ValidMutationRules.getNeighbourKinds(plusNode);
-            expect(actual.length).to.equal(2);
       });
 
       it("should return false when given a string addition expression", () => {
@@ -93,8 +39,8 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.PlusToken, sourceObj);
             const node: Node = nodes[0];
-            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
-            const actual = ValidMutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
+            mutationRules.setNodeFamily(node);
+            const actual = mutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
             expect(actual).to.equal(false);
       });
 
@@ -103,8 +49,8 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.GreaterThanToken, sourceObj);
             const node: Node = nodes[0];
-            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
-            const actual = ValidMutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
+            mutationRules.setNodeFamily(node);
+            const actual = mutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
             expect(actual).to.equal(true);
       });
 
@@ -113,8 +59,8 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.GreaterThanToken, sourceObj);
             const node: Node = nodes[0];
-            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
-            const actual = ValidMutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
+            mutationRules.setNodeFamily(node);
+            const actual = mutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
             expect(actual).to.equal(false);
       });
 
@@ -123,8 +69,8 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.StringLiteral, sourceObj);
             const node: Node = nodes[0];
-            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
-            const actual = ValidMutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
+            mutationRules.setNodeFamily(node);
+            const actual = mutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
             expect(actual).to.equal(true);
       });
 
@@ -133,8 +79,8 @@ describe("Testing ValidMutationRules", () => {
             const sourceObj = new SourceObjCreator(code).sourceObj;
             const nodes = nodeFinder.findObjectsOfSyntaxKind(SyntaxKind.LessThanToken, sourceObj);
             const node: Node = nodes[0];
-            ValidMutationRules.setNodeFamily(node, node.parent, node.parent.getChildAt(0));
-            const actual = ValidMutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
+            mutationRules.setNodeFamily(node);
+            const actual = mutationRules.traverseRuleTree(TEST_RULE_TREE, 0);
             expect(actual).to.equal(true);
       });
 });

--- a/src/CodeInspector/ValidMutationRules.ts
+++ b/src/CodeInspector/ValidMutationRules.ts
@@ -2,30 +2,26 @@ import { Node, SyntaxKind, Type } from "typescript";
 
 export class ValidMutationRules {
 
-      public static readonly RULETREE = {
+      public static readonly RULE_TREE = {
             [SyntaxKind.PlusToken]: {
                   [SyntaxKind.BinaryExpression]: {
                         [SyntaxKind.StringLiteral]: false
                   }
             },
             [SyntaxKind.GreaterThanToken || SyntaxKind.LessThanToken]: {
-                  [SyntaxKind.BinaryExpression]: true
+                  [SyntaxKind.BinaryExpression]: {
+                        [SyntaxKind.BinaryExpression] : false
+                  }
             }
       };
 
-      public static nodeKind: SyntaxKind;
-      public static parentKind: SyntaxKind;
-      public static neighbourKind: SyntaxKind;
-      public static ruleDepth;
+      public static nodeFamily: Array<SyntaxKind>;
 
       public static setNodeFamily (node: Node, parent: Node, neighbour: Node) {
-            this.nodeKind = node.kind;
-            this.parentKind = node.parent.kind;
-            this.neighbourKind = node.parent.getChildAt(0).kind;
-            this.ruleDepth = [
-                  ValidMutationRules.nodeKind,
-                  ValidMutationRules.parentKind,
-                  ValidMutationRules.neighbourKind
+            this.nodeFamily = [
+                  node.kind,
+                  parent.kind,
+                  neighbour.kind
             ];
       }
 
@@ -39,18 +35,16 @@ export class ValidMutationRules {
             return childKinds;
       }
 
-      public static traverseRuleTree (kind: Object, ruleDepth): boolean {
-            console.log("kind", kind);
-            if (typeof kind === "boolean") {
-                  console.log("hello", kind);
-                  return kind;
-            }
-            Object.keys(kind).forEach((syntaxKind) => {
-                  if (ValidMutationRules.ruleDepth[ruleDepth] === Number(syntaxKind)) {
-                        return ValidMutationRules.traverseRuleTree(kind[syntaxKind], ruleDepth + 1);
+      public static traverseRuleTree (tree: Object, nodeFamilyIndex: number): boolean {
+            const currentTreePosition = Object.keys(tree);
+            const indexOfFamilyMember = currentTreePosition.indexOf(this.nodeFamily[nodeFamilyIndex].toString());
+            if (indexOfFamilyMember >= 0) {
+                  if (typeof tree[currentTreePosition[0]] === "boolean") {
+                        return tree[currentTreePosition[0]];
                   }
-            });
-            console.log("depth", ruleDepth);
+                  return this.traverseRuleTree(tree[currentTreePosition[indexOfFamilyMember]], nodeFamilyIndex + 1);
+            }
+            return true;
       }
 
       public static isInBinaryExpression (node: Node): boolean {

--- a/src/CodeInspector/ValidMutationRules.ts
+++ b/src/CodeInspector/ValidMutationRules.ts
@@ -1,0 +1,69 @@
+import { Node, SyntaxKind, Type } from "typescript";
+
+export class ValidMutationRules {
+
+      public static readonly RULETREE = {
+            [SyntaxKind.PlusToken]: {
+                  [SyntaxKind.BinaryExpression]: {
+                        [SyntaxKind.StringLiteral]: false
+                  }
+            },
+            [SyntaxKind.GreaterThanToken || SyntaxKind.LessThanToken]: {
+                  [SyntaxKind.BinaryExpression]: true
+            }
+      };
+
+      public static nodeKind: SyntaxKind;
+      public static parentKind: SyntaxKind;
+      public static neighbourKind: SyntaxKind;
+      public static ruleDepth;
+
+      public static setNodeFamily (node: Node, parent: Node, neighbour: Node) {
+            this.nodeKind = node.kind;
+            this.parentKind = node.parent.kind;
+            this.neighbourKind = node.parent.getChildAt(0).kind;
+            this.ruleDepth = [
+                  ValidMutationRules.nodeKind,
+                  ValidMutationRules.parentKind,
+                  ValidMutationRules.neighbourKind
+            ];
+      }
+
+      public static getNeighbourKinds (node: Node) {
+            const childKinds: Array<SyntaxKind> = [];
+            node.parent.forEachChild((child) => {
+                  if (child.kind !== node.kind) {
+                        childKinds.push(child.kind);
+                  }
+            });
+            return childKinds;
+      }
+
+      public static traverseRuleTree (kind: Object, ruleDepth): boolean {
+            console.log("kind", kind);
+            if (typeof kind === "boolean") {
+                  console.log("hello", kind);
+                  return kind;
+            }
+            Object.keys(kind).forEach((syntaxKind) => {
+                  if (ValidMutationRules.ruleDepth[ruleDepth] === Number(syntaxKind)) {
+                        return ValidMutationRules.traverseRuleTree(kind[syntaxKind], ruleDepth + 1);
+                  }
+            });
+            console.log("depth", ruleDepth);
+      }
+
+      public static isInBinaryExpression (node: Node): boolean {
+            return node.parent.kind === SyntaxKind.BinaryExpression;
+      }
+
+      public static hasStringLiteralChild (node: Node): boolean {
+            let aChildIsStringLiteral = false;
+            node.parent.forEachChild((child) => {
+                  if (child.kind === SyntaxKind.StringLiteral) {
+                      aChildIsStringLiteral = true;
+                  }
+            });
+            return aChildIsStringLiteral;
+      }
+}

--- a/src/CodeInspector/ValidMutationRules.ts
+++ b/src/CodeInspector/ValidMutationRules.ts
@@ -14,30 +14,12 @@ export class ValidMutationRules {
                   }
             }
       };
+      public nodeFamily: Array<SyntaxKind>;
 
-      public static nodeFamily: Array<SyntaxKind>;
-
-      public static setNodeFamily (node: Node, parent: Node, neighbour: Node) {
-            this.nodeFamily = [
-                  node.kind,
-                  parent.kind,
-                  neighbour.kind
-            ];
-      }
-
-      public static getNeighbourKinds (node: Node) {
-            const childKinds: Array<SyntaxKind> = [];
-            node.parent.forEachChild((child) => {
-                  if (child.kind !== node.kind) {
-                        childKinds.push(child.kind);
-                  }
-            });
-            return childKinds;
-      }
-
-      public static traverseRuleTree (tree: Object, nodeFamilyIndex: number): boolean {
+      public traverseRuleTree (tree: Object, nodeFamilyIndex: number): boolean {
             const currentTreePosition = Object.keys(tree);
-            const indexOfFamilyMember = currentTreePosition.indexOf(this.nodeFamily[nodeFamilyIndex].toString());
+            const indexOfFamilyMember =
+            currentTreePosition.indexOf(this.nodeFamily[nodeFamilyIndex].toString());
             if (indexOfFamilyMember >= 0) {
                   if (typeof tree[currentTreePosition[0]] === "boolean") {
                         return tree[currentTreePosition[0]];
@@ -47,17 +29,11 @@ export class ValidMutationRules {
             return true;
       }
 
-      public static isInBinaryExpression (node: Node): boolean {
-            return node.parent.kind === SyntaxKind.BinaryExpression;
-      }
-
-      public static hasStringLiteralChild (node: Node): boolean {
-            let aChildIsStringLiteral = false;
-            node.parent.forEachChild((child) => {
-                  if (child.kind === SyntaxKind.StringLiteral) {
-                      aChildIsStringLiteral = true;
-                  }
-            });
-            return aChildIsStringLiteral;
+      public setNodeFamily (node: Node) {
+            this.nodeFamily = [
+                  node.kind,
+                  node.parent.kind,
+                  node.parent.getChildAt(0).kind
+            ];
       }
 }

--- a/src/mutationFactory/MutationFactory.ts
+++ b/src/mutationFactory/MutationFactory.ts
@@ -10,15 +10,15 @@ export class MutationFactory {
     ];
 
     public static syntaxMutationMap: IsyntaxMutationMap = {
-        29: [" < ", " <= ", ">=", " != ", " = ", " - ", " + ", " > ", " * ", " / "], // greater than
-        37: [" - ", " / ", " * "], // plus
-        38: [" + ",  " / ", " * "], // minus
-        39: [" / ", " < ", " <= ", ">=", " != ", " - ", " + ", " > "], // multiply
-        42: [" < ", " <= ", ">=", " != ", " - ", " + ", " > ", " * ", " / "], // percentage
-        44: ["++"],
-        54: [" && "],
-        101: [" false"], // true
-        86: [" true"] // false
+        [SyntaxKind.GreaterThanToken]: [" < ", " <= ", ">=", " != ", " = ", " - ", " + ", " > ", " * ", " / "],
+        [SyntaxKind.PlusToken]: [" - ", " / ", " * "],
+        [SyntaxKind.MinusToken]: [" + ",  " / ", " * "],
+        [SyntaxKind.AsteriskToken]: [" / ", " < ", " <= ", ">=", " != ", " - ", " + ", " > "],
+        [SyntaxKind.PercentToken]: [" < ", " <= ", ">=", " != ", " - ", " + ", " > ", " * ", " / "],
+        [SyntaxKind.MinusMinusToken]: ["++"],
+        [SyntaxKind.BarBarToken]: [" && "],
+        [SyntaxKind.TrueKeyword]: [" false"],
+        [SyntaxKind.FalseKeyword]: [" true"]
     };
 
     public static getSingleMutation (syntaxKind: SyntaxKind): string {

--- a/src/mutationFactory/MutationFactory.ts
+++ b/src/mutationFactory/MutationFactory.ts
@@ -6,15 +6,16 @@ export class MutationFactory {
     public static mutatableTokens: Array<SyntaxKind> = [
         SyntaxKind.PlusToken, SyntaxKind.MinusToken, SyntaxKind.TrueKeyword, SyntaxKind.FalseKeyword,
         SyntaxKind.PlusPlusToken, SyntaxKind.MinusMinusToken, SyntaxKind.BarBarToken, SyntaxKind.GreaterThanToken,
-        SyntaxKind.PercentToken
+        SyntaxKind.PercentToken, SyntaxKind.AsteriskToken
     ];
 
     public static syntaxMutationMap: IsyntaxMutationMap = {
-        [SyntaxKind.GreaterThanToken]: [" < ", " <= ", ">=", " != ", " = ", " - ", " + ", " > ", " * ", " / "],
+        [SyntaxKind.GreaterThanToken]: [" < ", " <= ", ">=", " !== ", " - ", " + ", " * ", " / "],
         [SyntaxKind.PlusToken]: [" - ", " / ", " * "],
         [SyntaxKind.MinusToken]: [" + ",  " / ", " * "],
-        [SyntaxKind.AsteriskToken]: [" / ", " < ", " <= ", ">=", " != ", " - ", " + ", " > "],
-        [SyntaxKind.PercentToken]: [" < ", " <= ", ">=", " != ", " - ", " + ", " > ", " * ", " / "],
+        [SyntaxKind.AsteriskToken]: [" / ", " < ", " <= ", ">=", " !== ", " - ", " + ", " > "],
+        [SyntaxKind.PercentToken]: [" < ", " <= ", ">=", " !== ", " - ", " + ", " > ", " * ", " / "],
+        [SyntaxKind.PlusPlusToken]: ["--"],
         [SyntaxKind.MinusMinusToken]: ["++"],
         [SyntaxKind.BarBarToken]: [" && "],
         [SyntaxKind.TrueKeyword]: [" false"],

--- a/src/supervisor/Supervisor.spec.ts
+++ b/src/supervisor/Supervisor.spec.ts
@@ -1,14 +1,14 @@
 import { expect } from "chai";
 import { Supervisor } from "./Supervisor";
 import { IMutatableNode } from "../../interfaces/IMutatableNode";
-import { Node } from "../../DTOs/Node";
+import { MutatableNode } from "../../DTOs/MutatableNode";
 
 describe("Testing Supervisor", () => {
 
     let supervisor: Supervisor;
     let stubNodes: Array<IMutatableNode>;
     beforeEach(() => {
-        stubNodes = createNodes(20);
+        stubNodes = createMutatableNodes(20);
         supervisor = new Supervisor(stubNodes);
     });
 
@@ -20,21 +20,21 @@ describe("Testing Supervisor", () => {
 
     it("should put 3 nodes into the first core with 12 nodes and 4 cores", () => {
         supervisor.logicalCores = 4;
-        const splitNodes = supervisor.splitNodes(createNodes(12));
+        const splitNodes = supervisor.splitNodes(createMutatableNodes(12));
         expect(splitNodes[0].length).to.equal(3);
     });
 
     it("should put 2 nodes into the last core with 11 nodes and 4 cores", () => {
         supervisor.logicalCores = 4;
-        const splitNodes = supervisor.splitNodes(createNodes(11));
+        const splitNodes = supervisor.splitNodes(createMutatableNodes(11));
         expect(splitNodes[supervisor.logicalCores - 1].length).to.equal(2);
     });
 });
 
-function createNodes (numberOfNodes: Number): Array<IMutatableNode> {
+function createMutatableNodes (numberOfNodes: Number): Array<IMutatableNode> {
     const nodes: Array<IMutatableNode> = [];
     for (let i = 0; i < numberOfNodes; i++) {
-        nodes.push(new Node(i * 2, {pos: i, end: i + 1}, ""));
+        nodes.push(new MutatableNode(i * 2, {pos: i, end: i + 1}, ""));
     }
     return nodes;
 }

--- a/testProject/src/FileTwo.ts
+++ b/testProject/src/FileTwo.ts
@@ -1,8 +1,8 @@
 export class FileTwo {
-    public getEvenNumbers (limit: number) {
+    public getEvenNumbers (limit: number): Array <number> {
         const numbers = [];
         for (let i = 0; i < limit + 1; i++) {
-            if (i % 2 === 0){
+            if (i % 2 === 0 && 1 > 0){
                 numbers.push(i);
             }
         }

--- a/testProject/src/HelloWorld.spec.ts
+++ b/testProject/src/HelloWorld.spec.ts
@@ -36,4 +36,10 @@ describe("Test Project addition function", () => {
         expect(actual).to.equal(expected);
     });
 
+    it("should return hello: 1", () => {
+        const expected = "helloworld";
+        const actual = hello.helloStringLiteral();
+        expect(actual).to.equal("hello: " + "1");
+    });
+
 });

--- a/testProject/src/HelloWorld.ts
+++ b/testProject/src/HelloWorld.ts
@@ -18,4 +18,8 @@ export class HelloWorld {
     public helloStrings (h: string, w: string) {
         return h + w;
     }
+
+    public helloStringLiteral () {
+        return "hello: " + "1";
+    }
 }

--- a/testUtilities/SourceObjCreator.ts
+++ b/testUtilities/SourceObjCreator.ts
@@ -1,0 +1,8 @@
+import { createSourceFile, ScriptTarget, SourceFile } from "typescript";
+
+export class SourceObjCreator {
+      public sourceObj: SourceFile;
+      constructor (code: string) {
+            this.sourceObj = createSourceFile("", code, ScriptTarget.ES5, true);
+      }
+}

--- a/testUtilities/SpecificNodeFinder.ts
+++ b/testUtilities/SpecificNodeFinder.ts
@@ -1,0 +1,19 @@
+import { SyntaxKind, Node } from "typescript";
+
+export class SpecificNodeFinder {
+      public retrievedObjects = [];
+
+      public findObjectsOfSyntaxKind (kind: SyntaxKind, sourceObject) {
+            return this.findTokenObjectsOfKind(sourceObject, kind);
+      }
+
+      public findTokenObjectsOfKind (object: Node, kind: SyntaxKind) {
+            if (object.kind === kind) {
+                  this.retrievedObjects.push(object);
+            }
+            object.forEachChild((element) => {
+                  this.findTokenObjectsOfKind(element, kind);
+            });
+            return this.retrievedObjects;
+      }
+}

--- a/testUtilities/SpecificNodeFinder.ts
+++ b/testUtilities/SpecificNodeFinder.ts
@@ -7,7 +7,7 @@ export class SpecificNodeFinder {
             return this.findTokenObjectsOfKind(sourceObject, kind);
       }
 
-      public findTokenObjectsOfKind (object: Node, kind: SyntaxKind) {
+      private findTokenObjectsOfKind (object: Node, kind: SyntaxKind) {
             if (object.kind === kind) {
                   this.retrievedObjects.push(object);
             }


### PR DESCRIPTION
Can now use a `RULE_TREE` to specify in what configuration a node is not allowed to be mutated
This rule tree is a `JSON `object which contains syntax tokens and their relationships
``` JSON
{
            [SyntaxKind.PlusToken]: {
                  [SyntaxKind.BinaryExpression]: {
                        [SyntaxKind.StringLiteral]: false
                  }
            },
            [SyntaxKind.GreaterThanToken || SyntaxKind.LessThanToken]: {
                  [SyntaxKind.BinaryExpression]: {
                        [SyntaxKind.BinaryExpression] : false
                  }
            }
};
```

e.g.

`"hello" + "world";`

The `plus` node would not be mutated.