### PR TITLE
Minify results

### DIFF
--- a/DTOs/EndResult.ts
+++ b/DTOs/EndResult.ts
@@ -7,6 +7,15 @@ export class EndResult {
         public readonly runner: string,
         public readonly runnerConf: Object,
         public readonly duration: IDurationFormat,
+        public readonly fileList: Array<{
+            fileName: string, mutantsKilled: number,
+            mutantsSurvived: number, fileMutationScore: number
+        }>,
+        public readonly overallScores: {
+            totalKilledMutants: number,
+            totalSurvivingMutants: number,
+            mutationScore: number
+        },
         public readonly results: Array<MutationResult>
     ){}
 }

--- a/DTOs/EndResult.ts
+++ b/DTOs/EndResult.ts
@@ -8,8 +8,9 @@ export class EndResult {
         public readonly runnerConf: Object,
         public readonly duration: IDurationFormat,
         public readonly fileList: Array<{
-            fileName: string, mutantsKilled: number,
-            mutantsSurvived: number, fileMutationScore: number
+            fileName: string,
+            mutantsSurvived: number,
+            totalMutationsOnFile: number
         }>,
         public readonly overallScores: {
             totalKilledMutants: number,

--- a/DTOs/MutatableNode.ts
+++ b/DTOs/MutatableNode.ts
@@ -4,6 +4,9 @@ export class MutatableNode implements IMutatableNode{
     constructor (
         public syntaxType: number,
         public positions: { pos: number, end: number },
-        public parentFileName: string
+        public parentFileName: string,
+        public parentFilePath: string,
+        public associatedTestFilePath: string,
+        public plainText: string
     ) {}
 }

--- a/DTOs/MutationResult.ts
+++ b/DTOs/MutationResult.ts
@@ -1,17 +1,18 @@
+import { IMutationResult } from "../interfaces/IMutationResult";
 import { IMutationAttemptFailure } from "../interfaces/IMutationAttemptFailure";
 
-export class MutationResult {
+export class MutationResult implements IMutationResult{
       public readonly SRC_FILE_PATH: string;
       public readonly SRC_FILE: string;
 
       public testFilePath: string;
       public origionalCode: Array<{lineText: string, lineNumber: number}> = [];
       public mutatedCode: Array<{lineText: string, lineNumber: number}> = [];
-      public numberOfFailedTests: number;
-      public numberOfPassedTests: number;
-      public mutantKilled: boolean;
 
       public mutationAttemptFailure: IMutationAttemptFailure;
+
+      public targetNode: string;
+      public nodeModification: string;
 
       public constructor (
             srcPath: string,

--- a/interfaces/IMutationResult.ts
+++ b/interfaces/IMutationResult.ts
@@ -1,0 +1,15 @@
+import { IMutationAttemptFailure } from "../interfaces/IMutationAttemptFailure";
+
+export interface IMutationResult {
+    SRC_FILE_PATH: string;
+    SRC_FILE: string;
+
+    testFilePath: string;
+    origionalCode: Array<{ lineText: string, lineNumber: number }> = [];
+    mutatedCode: Array<{ lineText: string, lineNumber: number }> = [];
+
+    mutationAttemptFailure: IMutationAttemptFailure;
+
+    targetNode: string;
+    nodeModification: string;
+}

--- a/interfaces/IMutationResult.ts
+++ b/interfaces/IMutationResult.ts
@@ -5,8 +5,8 @@ export interface IMutationResult {
     SRC_FILE: string;
 
     testFilePath: string;
-    origionalCode: Array<{ lineText: string, lineNumber: number }> = [];
-    mutatedCode: Array<{ lineText: string, lineNumber: number }> = [];
+    origionalCode: Array<{ lineText: string, lineNumber: number }>;
+    mutatedCode: Array<{ lineText: string, lineNumber: number }>;
 
     mutationAttemptFailure: IMutationAttemptFailure;
 

--- a/src/mocha-testRunner/Mocha-TestRunner.ts
+++ b/src/mocha-testRunner/Mocha-TestRunner.ts
@@ -18,27 +18,13 @@ export class MochaTestRunner {
         return new Promise((resolve, reject) => {
         try{
             runner = this.mocha.run(() => {
-                    mResultManager.setNumberOfTests(this.createTestResult(runner.stats));
-                    resolve();
-                });
+                if (runner.stats.failures < 1) {
+                    resolve("survived");
+                }});
         } catch (error) {
-            Logger.fatal("Mocha Runner status:", runner);
+            Logger.fatal("Mocha Runner Failed. Status:", runner);
+            reject();
         }
         });
-    }
-
-    public createTestResult (stats): ITestResult {
-        if (stats === void 0){
-            Logger.fatal("Mocha Test result returned undefined", this);
-            throw new Error("Test result is undefined");
-        }
-        const result =
-        {
-            passed: stats.passes,
-            failed: stats.failures,
-            totalRan: stats.tests,
-            duration: stats.duration
-        };
-        return result;
     }
 }

--- a/src/mocha-testRunner/Mocha-TestRunner.ts
+++ b/src/mocha-testRunner/Mocha-TestRunner.ts
@@ -20,7 +20,7 @@ export class MochaTestRunner {
             runner = this.mocha.run(() => {
                 if (runner.stats.failures < 1) {
                     resolve("survived");
-                }});
+                } else { resolve("killed"); }});
         } catch (error) {
             Logger.fatal("Mocha Runner Failed. Status:", runner);
             reject();

--- a/src/multipleNodeMutator/MultipleNodeMutator.ts
+++ b/src/multipleNodeMutator/MultipleNodeMutator.ts
@@ -18,6 +18,7 @@ import { Config } from "../../DEVCONFIG";
 
 
 export class MultipleNodeMutator {
+
       private mutationResultManager: MutationResultManager;
       private mochaRunner: MochaTestRunner;
       private sourceCodeModifier: SourceCodeModifier;
@@ -55,7 +56,7 @@ export class MultipleNodeMutator {
                   this.mutationResultManager.getCurrentMutationResult().mutationAttemptFailure =
                   new MAttemptFail(
                         this.errorString,
-                        this.currentNode.syntaxType.toString() + " --> " +
+                        this.currentNode.syntaxType.toString() + "  -->  " +
                         mutationOption,
                         this.currentNode
                   );
@@ -68,17 +69,18 @@ export class MultipleNodeMutator {
                   .then((resolve) =>
                         {
                               if (resolve === "survived" || this.errorString.length > 0) {
-                                    this.commitMutationToList();
+                                    this.commitSurvivingMutant();
                                     this.mutationResultManager.setCurrentMutationResult(void 0);
+                              } else {
+                                    this.commitKilledMutant();
                               }
                         });
                   this.cleanFiles();
             }
       }
 
-      private setFileInformation () {
-            const fileObject = new FileObject(this.currentNode.parentFilePath,
-                  this.currentNode.associatedTestFilePath);
+      private setFileInformation (): void {
+            const fileObject = new FileObject(this.currentNode.parentFilePath, this.currentNode.associatedTestFilePath);
             fileObject.coreNumber = process.pid;
             this.fileHandler = new FileHandler(fileObject);
       }
@@ -97,25 +99,31 @@ export class MultipleNodeMutator {
             }
       }
 
-      private commitMutationToList () {
+      private commitSurvivingMutant (): void {
             this.mutationResultManager.setCurrentSourceCodeModifierAndSourceObj(
                   this.sourceCodeModifier);
             this.mutationResultManager.setMutationResultData(this.testFile, this.currentNode);
             this.mutationResultManager.addMutationResultToList();
       }
 
-      private setSourceCodeInformation (mutationOptions: string) {
+      private commitKilledMutant (): void {
+            this.mutationResultManager.getCurrentMutationResult().mutatedCode = null;
+            this.mutationResultManager.getCurrentMutationResult().origionalCode = null;
+            this.mutationResultManager.addMutationResultToList();
+      }
+
+      private setSourceCodeInformation (mutationOptions: string): void {
             this.sourceCodeModifier.resetModified();
             this.sourceCodeModifier.modifyCode(this.currentNode, mutationOptions);
       }
 
-      private createMutatedFiles () {
+      private createMutatedFiles (): void {
             this.srcFile = this.fileHandler.writeTempSourceModifiedFile(
                   this.sourceCodeModifier.getModifiedSourceCode());
             this.testFile = this.fileHandler.createTempTestModifiedFile();
       }
 
-      private cleanFiles () {
+      private cleanFiles (): void {
             Cleaner.deleteTestFile(this.testFile);
             Cleaner.deleteSourceFile(this.srcFile);
       }

--- a/src/mutationResultManager/MutationResultManager.spec.ts
+++ b/src/mutationResultManager/MutationResultManager.spec.ts
@@ -35,16 +35,6 @@ describe("Mutation Result Manager", () => {
         testResult = {passed: "0", failed: "2", totalRan: "0", duration: "20"};
     });
 
-    it("ITestResult.passed of 0 should set passed tests to 0", () => {
-        mResultManager.setNumberOfTests(testResult);
-        expect(mutationResult.numberOfPassedTests).to.equal(0);
-    });
-
-    it("ITestResult.failed of 2 should set passed tests to 2", () => {
-        mResultManager.setNumberOfTests(testResult);
-        expect(mutationResult.numberOfFailedTests).to.equal(2);
-    });
-
     it("should get a list of one method when the code contains one", () => {
         const methodNames = mResultManager.getAllMethodNames();
         expect(methodNames.length).to.eql(1);
@@ -95,13 +85,5 @@ describe("Mutation Result Manager", () => {
         );
         const methodNames = mResultManager.getParentMethodBoundsOfMutatedLine(120);
         expect(methodNames).to.eql({pos: 110, end: 198});
-    });
-
-    it("should return true (killed) with failed tests > 0", () => {
-        expect(mResultManager.wasMutantKilled(1)).to.equal(true);
-    });
-
-    it("should return false (survived) with failed tests = 0", () => {
-        expect(mResultManager.wasMutantKilled(0)).to.equal(false);
     });
 });

--- a/src/mutationResultManager/MutationResultManager.ts
+++ b/src/mutationResultManager/MutationResultManager.ts
@@ -14,9 +14,6 @@ export class MutationResultManager {
     private currentMutationResult: MutationResult;
     private sourceCodeModifier: SourceCodeModifier;
     private currentSourceCodeObject: ts.SourceFile;
-    public constructor (
-    ) {
-    }
 
     public setCurrentMutationResult (mResult: MutationResult): void {
         this.currentMutationResult = mResult;
@@ -52,13 +49,6 @@ export class MutationResultManager {
         this.currentMutationResult.testFilePath = filename;
     }
 
-    public setNumberOfTests (testResult: ITestResult): void {
-        this.currentMutationResult.numberOfPassedTests = parseInt(testResult.passed, 0);
-        this.currentMutationResult.numberOfFailedTests = parseInt(testResult.failed, 0);
-        this.currentMutationResult.mutantKilled =
-        this.wasMutantKilled(this.currentMutationResult.numberOfFailedTests);
-    }
-
     public setSourceCodeLines (
         code: {origional: string, mutated: string},
         bounds: {pos: number, end: number}
@@ -71,11 +61,6 @@ export class MutationResultManager {
         } catch (error) {
             Logger.fatal("Mutation result Manager could not set source code lines", error);
         }
-    }
-
-    // was the mutant killed? true is killed (good)
-    public wasMutantKilled (failedTests: number): boolean {
-        return failedTests > 0;
     }
 
     public getParentMethodBoundsOfMutatedLine (characterOfMutation: number) {

--- a/src/mutationResultManager/MutationResultManager.ts
+++ b/src/mutationResultManager/MutationResultManager.ts
@@ -51,8 +51,7 @@ export class MutationResultManager {
 
     public setSourceCodeLines (
         code: {origional: string, mutated: string},
-        bounds: {pos: number, end: number}
-    ): void {
+        bounds: {pos: number, end: number}): void {
         try {
             const methodStartLine = ts.getLineAndCharacterOfPosition(this.currentSourceCodeObject, bounds.pos).line;
             const methodEndLine = ts.getLineAndCharacterOfPosition(this.currentSourceCodeObject, bounds.end).line;

--- a/src/outputResults/OutputToJSON.ts
+++ b/src/outputResults/OutputToJSON.ts
@@ -10,7 +10,9 @@ export class OutputToJSON {
             const header = {
                 runner: collatedResults.runner,
                 config: collatedResults.runnerConf,
-                duration: collatedResults.duration
+                duration: collatedResults.duration,
+                fileList: collatedResults.fileList,
+                overallScores: collatedResults.overallScores
             };
             const results = collatedResults.results;
             const transformStream = JSONStream.stringify();

--- a/src/supervisor/Supervisor.spec.ts
+++ b/src/supervisor/Supervisor.spec.ts
@@ -39,8 +39,8 @@ describe("Supervisor", () => {
         sup.threadResults = [threadResultsFileOne];
         expect(sup.getIndividualFileResults()).to.eql([{
             fileName: "FileOne.ts",
-            totalSurvivingMutants: 1,
-            allGeneratedMutationsForFile: 1
+            mutantsSurvived: 1,
+            totalMutationsOnFile: 1
         }]);
     });
 
@@ -50,8 +50,8 @@ describe("Supervisor", () => {
         sup.threadResults = [threadResultsFileOne, threadResultsFileOne];
         expect(sup.getIndividualFileResults()).to.eql([{
             fileName: "FileOne.ts",
-            totalSurvivingMutants: 2,
-            allGeneratedMutationsForFile: 2
+            mutantsSurvived: 2,
+            totalMutationsOnFile: 2
         }]);
     });
 
@@ -61,12 +61,12 @@ describe("Supervisor", () => {
         sup.threadResults = [threadResultsFileOne, threadResultsFileTwo];
         expect(sup.getIndividualFileResults()).to.eql([{
             fileName: "FileOne.ts",
-            totalSurvivingMutants: 1,
-            allGeneratedMutationsForFile: 1
+            mutantsSurvived: 1,
+            totalMutationsOnFile: 1
         }, {
             fileName: "FileTwo.ts",
-            totalSurvivingMutants: 1,
-            allGeneratedMutationsForFile: 1
+            mutantsSurvived: 1,
+            totalMutationsOnFile: 1
         }]);
     });
 });

--- a/src/supervisor/Supervisor.spec.ts
+++ b/src/supervisor/Supervisor.spec.ts
@@ -1,0 +1,31 @@
+import { Supervisor } from "./Supervisor";
+import { CreateMutatableNodes } from "../../testUtilities/CreateMutatableNodes";
+import { IMutationResult } from "../../interfaces/IMutationResult";
+import { expect } from "chai";
+
+describe("Supervisor", () => {
+    let sup: Supervisor;
+    beforeEach(() => {
+        sup = new Supervisor(
+            CreateMutatableNodes.createMutatableNodes(10));
+    });
+
+    it("should return one file name with a count of surviving + all mutations", () => {
+        sup.threadResults = [{
+            SRC_FILE: CreateMutatableNodes.filename, mutatedCode: [],
+            mutationAttemptFailure: {
+                reasonForFailure: "",
+                attemptedMutation: "",
+                nodeToBeMutated:
+                CreateMutatableNodes.createMutatableNodes(1)[0]}, nodeModification: "",
+            origionalCode: [], testFilePath: CreateMutatableNodes.testPath,
+            targetNode: "", SRC_FILE_PATH: CreateMutatableNodes.filePath
+        }];
+        console.log(sup.getIndividualFileResults());
+        expect(sup.getIndividualFileResults()).to.eql([{
+            fileName: CreateMutatableNodes.filename,
+            totalSurvivingMutants: 1,
+            allGeneratedMutationsForFile: 10
+        }]);
+    });
+});

--- a/src/supervisor/Supervisor.spec.ts
+++ b/src/supervisor/Supervisor.spec.ts
@@ -1,31 +1,72 @@
+import { expect } from "chai";
 import { Supervisor } from "./Supervisor";
+import { MutatableNode } from "../../DTOs/MutatableNode";
 import { CreateMutatableNodes } from "../../testUtilities/CreateMutatableNodes";
 import { IMutationResult } from "../../interfaces/IMutationResult";
-import { expect } from "chai";
 
 describe("Supervisor", () => {
     let sup: Supervisor;
+    const threadResultsFileOne = {
+        SRC_FILE: "FileOne.ts", mutatedCode: [],
+        mutationAttemptFailure: {
+            reasonForFailure: "",
+            attemptedMutation: "",
+            nodeToBeMutated:
+            CreateMutatableNodes.createMutatableNodes(1)[0]}, nodeModification: "",
+        origionalCode: [], testFilePath: CreateMutatableNodes.testPath,
+        targetNode: "", SRC_FILE_PATH: "/src/FileOne.ts"
+    };
+    const threadResultsFileTwo = {
+        SRC_FILE: "FileTwo.ts", mutatedCode: [],
+        mutationAttemptFailure: {
+            reasonForFailure: "",
+            attemptedMutation: "",
+            nodeToBeMutated:
+            CreateMutatableNodes.createMutatableNodes(1)[0]}, nodeModification: "",
+        origionalCode: [], testFilePath: CreateMutatableNodes.testPath,
+        targetNode: "", SRC_FILE_PATH: "/src/FileTwo.ts"
+    };
+    const fileOneMutatableNode = new MutatableNode(1, { pos: 1, end: 2 }, "FileOne.ts",
+        "/src/FileOne.ts", "./FileOne.ts", "");
+    const fileTwoMutatableNode = new MutatableNode(1, { pos: 1, end: 2 }, "FileTwo.ts",
+        "/src/FileTwo.ts", "./FileTwo.ts", "");
+
     beforeEach(() => {
-        sup = new Supervisor(
-            CreateMutatableNodes.createMutatableNodes(10));
+        sup = new Supervisor([fileOneMutatableNode]);
     });
 
-    it("should return one file name with a count of surviving + all mutations", () => {
-        sup.threadResults = [{
-            SRC_FILE: CreateMutatableNodes.filename, mutatedCode: [],
-            mutationAttemptFailure: {
-                reasonForFailure: "",
-                attemptedMutation: "",
-                nodeToBeMutated:
-                CreateMutatableNodes.createMutatableNodes(1)[0]}, nodeModification: "",
-            origionalCode: [], testFilePath: CreateMutatableNodes.testPath,
-            targetNode: "", SRC_FILE_PATH: CreateMutatableNodes.filePath
-        }];
-        console.log(sup.getIndividualFileResults());
+    it("should return one file object with a count of surviving + all mutations", () => {
+        sup.threadResults = [threadResultsFileOne];
         expect(sup.getIndividualFileResults()).to.eql([{
-            fileName: CreateMutatableNodes.filename,
+            fileName: "FileOne.ts",
             totalSurvivingMutants: 1,
-            allGeneratedMutationsForFile: 10
+            allGeneratedMutationsForFile: 1
+        }]);
+    });
+
+    it("should return one file object with a count of surviving + all mutations when given 2 results", () => {
+        sup = new Supervisor(
+            [fileOneMutatableNode, fileOneMutatableNode]);
+        sup.threadResults = [threadResultsFileOne, threadResultsFileOne];
+        expect(sup.getIndividualFileResults()).to.eql([{
+            fileName: "FileOne.ts",
+            totalSurvivingMutants: 2,
+            allGeneratedMutationsForFile: 2
+        }]);
+    });
+
+    it(`should return two file objects with a count of surviving +
+    all mutations when given 2 different results`, () => {
+        sup = new Supervisor([fileOneMutatableNode, fileTwoMutatableNode]);
+        sup.threadResults = [threadResultsFileOne, threadResultsFileTwo];
+        expect(sup.getIndividualFileResults()).to.eql([{
+            fileName: "FileOne.ts",
+            totalSurvivingMutants: 1,
+            allGeneratedMutationsForFile: 1
+        }, {
+            fileName: "FileTwo.ts",
+            totalSurvivingMutants: 1,
+            allGeneratedMutationsForFile: 1
         }]);
     });
 });

--- a/src/supervisor/Supervisor.ts
+++ b/src/supervisor/Supervisor.ts
@@ -45,18 +45,19 @@ export class Supervisor {
             }
       }
 
-      public getIndividualFileResults (): Array<any> {
-
-            return this.threadResults.map((result) => {
+      public getIndividualFileResults () {
+            const indFileResults = this.threadResults.map((result) => {
                   return {
                         fileName: result.SRC_FILE,
                         totalSurvivingMutants: this.threadResults.filter((resultFilter) =>
                               resultFilter.SRC_FILE === result.SRC_FILE).length,
                         allGeneratedMutationsForFile: this.inputNodes.filter((inputNodes) => {
-                              return basename(inputNodes.parentFilePath) === basename(result.SRC_FILE);
+                              return inputNodes.parentFilePath === result.SRC_FILE_PATH;
                         }).length
                   };
             });
+            return indFileResults.filter((item, index, array) =>
+            index === array.findIndex((el) => el.fileName === item.fileName));
       }
 
       private createWorkerMessagers (individualWorker: ChildProcess) {

--- a/src/supervisor/Supervisor.ts
+++ b/src/supervisor/Supervisor.ts
@@ -49,9 +49,9 @@ export class Supervisor {
             const indFileResults = this.threadResults.map((result) => {
                   return {
                         fileName: result.SRC_FILE,
-                        totalSurvivingMutants: this.threadResults.filter((resultFilter) =>
+                        mutantsSurvived: this.threadResults.filter((resultFilter) =>
                               resultFilter.SRC_FILE === result.SRC_FILE).length,
-                        allGeneratedMutationsForFile: this.inputNodes.filter((inputNodes) => {
+                        totalMutationsOnFile: this.inputNodes.filter((inputNodes) => {
                               return inputNodes.parentFilePath === result.SRC_FILE_PATH;
                         }).length
                   };

--- a/src/supervisor/Supervisor.ts
+++ b/src/supervisor/Supervisor.ts
@@ -50,9 +50,9 @@ export class Supervisor {
                   return {
                         fileName: result.SRC_FILE,
                         mutantsSurvived: this.threadResults.filter((resultFilter) =>
-                              resultFilter.SRC_FILE === result.SRC_FILE).length,
-                        totalMutationsOnFile: this.inputNodes.filter((inputNodes) => {
-                              return inputNodes.parentFilePath === result.SRC_FILE_PATH;
+                              resultFilter.SRC_FILE === result.SRC_FILE && resultFilter.mutatedCode !== null).length,
+                        totalMutationsOnFile: this.threadResults.filter((allResults) => {
+                              return allResults.SRC_FILE === result.SRC_FILE;
                         }).length
                   };
             });
@@ -102,6 +102,7 @@ export class Supervisor {
                   this.threadResults
             );
             Logger.dumpLogToConsole();
+            console.log("number of input nodes", this.inputNodes.length);
             console.log("");
             console.log("end result", endResult.fileList);
             OutputToJSON.writeResults(endResult);
@@ -109,8 +110,9 @@ export class Supervisor {
       }
 
       private getOverallMutationScore () {
-            const mutationsPerformed = this.inputNodes.length;
-            const survivingMutants = this.threadResults.length;
+            const mutationsPerformed = this.threadResults.length;
+            const survivingMutants = this.getIndividualFileResults()
+                  .map((item) => item.mutantsSurvived).reduce((accumulator, current) => accumulator += current);
             const numberOfKilledOrErrored = mutationsPerformed - survivingMutants;
             return {
                   totalKilledMutants: numberOfKilledOrErrored,

--- a/src/supervisor/Supervisor.ts
+++ b/src/supervisor/Supervisor.ts
@@ -11,6 +11,8 @@ import { Cleaner } from "../cleanup/Cleaner";
 import { MathFunctions } from "../maths/MathFunctions";
 import { OutputToJSON } from "../outputResults/OutputToJSON";
 import { Logger } from "../logging/Logger";
+import { IMutationResult } from "../../interfaces/IMutationResult";
+import { basename } from "path";
 
 process.on("SIGINT", () => {
       Logger.fatal("User Pressed Ctrl + C: SIGINT Caught. Program ending.");
@@ -24,14 +26,14 @@ export class Supervisor {
       public startTimestamp: number;
       public logicalCores: number;
       public workers: Array<ChildProcess> = new Array<ChildProcess>();
-      public nodes: Array<Array<IMutatableNode>>;
-      public threadResults = [];
+      public splitNodes: Array<Array<IMutatableNode>>;
+      public threadResults: Array<IMutationResult> = [];
 
-      constructor (nodes: Array<IMutatableNode>) {
+      constructor (private inputNodes: Array<IMutatableNode>) {
             this.logicalCores = os.cpus().length;
             this.startTimestamp = new Date().getTime();
             Logger.log("Splitting nodes among workers");
-            this.nodes = MathFunctions.divideItemsAmongArrays(nodes, this.logicalCores);
+            this.splitNodes = MathFunctions.divideItemsAmongArrays(inputNodes, this.logicalCores);
       }
 
       public spawnWorkers () {
@@ -39,8 +41,22 @@ export class Supervisor {
                   this.workers.push(worker.fork("./src/Worker.ts", [], {}));
                   Logger.info("Creating Worker: ", i);
                   this.createWorkerMessagers(this.workers[i]);
-                  this.workers[i].send(JSON.stringify(this.nodes[i]));
+                  this.workers[i].send(JSON.stringify(this.splitNodes[i]));
             }
+      }
+
+      public getIndividualFileResults (): Array<any> {
+
+            return this.threadResults.map((result) => {
+                  return {
+                        fileName: result.SRC_FILE,
+                        totalSurvivingMutants: this.threadResults.filter((resultFilter) =>
+                              resultFilter.SRC_FILE === result.SRC_FILE).length,
+                        allGeneratedMutationsForFile: this.inputNodes.filter((inputNodes) => {
+                              return basename(inputNodes.parentFilePath) === basename(result.SRC_FILE);
+                        }).length
+                  };
+            });
       }
 
       private createWorkerMessagers (individualWorker: ChildProcess) {
@@ -80,10 +96,30 @@ export class Supervisor {
                   ConfigManager.testRunner,
                   ConfigManager.runnerConfig,
                   timeTaken,
+                  this.getIndividualFileResults(),
+                  this.getOverallMutationScore(),
                   this.threadResults
             );
             Logger.dumpLogToConsole();
+            console.log("");
+            console.log("end result", endResult.fileList);
             OutputToJSON.writeResults(endResult);
             Cleaner.cleanRemainingFiles();
-        }
+      }
+
+      private getOverallMutationScore () {
+            const mutationsPerformed = this.inputNodes.length;
+            const survivingMutants = this.threadResults.length;
+            const numberOfKilledOrErrored = mutationsPerformed - survivingMutants;
+            return {
+                  totalKilledMutants: numberOfKilledOrErrored,
+                  totalSurvivingMutants: survivingMutants,
+                  mutationScore: this.calculateMutationScore(
+                        numberOfKilledOrErrored, mutationsPerformed)
+            };
+      }
+
+      private calculateMutationScore (killed: number, total: number): number {
+            return Number((killed / total * 100).toFixed(2));
+      }
 }

--- a/testUtilities/CreateMutatableNodes.ts
+++ b/testUtilities/CreateMutatableNodes.ts
@@ -2,10 +2,21 @@ import { IMutatableNode } from "../interfaces/IMutatableNode";
 import { MutatableNode } from "../DTOs/MutatableNode";
 export class CreateMutatableNodes {
 
+      public static filename = "filename.ts";
+      public static filePath = "C:/filePath/filename.ts";
+      public static testPath = "C:filePath/test/filename.spec.ts";
+      public static plainText = "const x = 1;";
       public static createMutatableNodes (numberOfNodes: Number): Array<IMutatableNode> {
             const nodes: Array<IMutatableNode> = [];
             for (let i = 0; i < numberOfNodes; i++) {
-                  nodes.push(new MutatableNode(i * 2, { pos: i, end: i + 1 }, ""));
+                  nodes.push(new MutatableNode(
+                        i,
+                        { pos: i, end: i + 1 },
+                        this.filename,
+                        this.filePath,
+                        this.testPath,
+                        this.plainText
+                  ));
             }
             return nodes;
       }


### PR DESCRIPTION
The output of the program was considered far too large when performing many mutations. Furthermore a JSON file at 50mb would crash the angular front end and so would make evaluation impossible.

This addition creates an overall summary of results along with a "per file" analysis.
Also for killed mutations, the results are nulled out since we don't care about the changes made.