### PR TITLE
No longer crashes on silent output due to memory constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:watch": "mocha --opts ./mocha.opts --watch",
     "build": "tsc",
     "lint": "tslint ./src/**/*.ts",
-    "start": "ts-node --max_old_space_size=8192 ./src/index.ts",
+    "start": "node --max_old_space_size=8192 -r ts-node/register ./src/index.ts",
     "push": "npm run test && npm run lint && git push"
   },
   "repository": {

--- a/src/supervisor/Supervisor.ts
+++ b/src/supervisor/Supervisor.ts
@@ -49,7 +49,9 @@ export class Supervisor {
 
       public spawnWorkers () {
             for (let i = 0; i < this.logicalCores; i++) {
-                  this.workers.push(worker.fork("./src/Worker.ts", [], {silent: false}));
+                  this.workers.push(worker.fork("./src/Worker.ts", [], {
+                        // ts claims this is invalid but it is correct
+                        stdio: ["ipc", "ignore", "ignore"] }));
                   Logger.info("Creating Worker: ", i);
                   this.createWorkerMessagers(this.workers[i]);
                   this.workers[i].send(JSON.stringify(this.splitNodes[i]));


### PR DESCRIPTION
ts-node total memory fix thanks to this issue 
https://github.com/TypeStrong/ts-node/issues/566

The stdio is flagging up on vscode as a problem but it is correct from the documentation of node and functions as expected.
https://nodejs.org/api/child_process.html#child_process_options_stdio
`
this.workers.push(worker.fork("./src/Worker.ts", [], {
                        // ts claims this is invalid but it is correct
                        stdio: ["ipc", "ignore", "ignore"] }));
`